### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,19 +6,25 @@ on:
       - main
   pull_request:
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   CodeQL-Build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: javascript
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4.5.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0

--- a/.github/workflows/purge-readme-image-cache.yml
+++ b/.github/workflows/purge-readme-image-cache.yml
@@ -4,13 +4,15 @@ on:
   schedule:
     - cron: '34 18 * * */7'
 
+permissions: {}
+
 jobs:
   purge:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
-
-    - run: >
-        curl -sL https://github.com/${GITHUB_REPOSITORY} |
-        grep -oE '<img src="https?://camo.githubusercontent.com/[^"]+' |
-        sed -e 's/<img src="//' |
-        xargs -I % curl -sX PURGE %
+      - run: >
+          curl -sL "https://github.com/${GITHUB_REPOSITORY}" |
+          grep -oE '<img src="https?://camo.githubusercontent.com/[^"]+' |
+          sed -e 's/<img src="//' |
+          xargs -r -I '{}' curl -sX PURGE '{}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,15 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "${GITHUB_CONTEXT}"
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install github/hub
         run: |

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -5,29 +5,35 @@ on:
     - cron: '14 14 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         os:
-          - 'ubuntu-latest'
-          - 'ubuntu-20.04'
+          - 'ubuntu-24.04'
+          # Keep the previous LTS runner in the matrix for compatibility coverage.
+          - 'ubuntu-22.04'
           - 'macos-latest'
           - 'windows-latest'
         mdbook-version:
           - 'latest'
           - '0.4.0'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v2.0.0
+        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2.0.0
         with:
           mdbook-version: ${{ matrix.mdbook-version }}
 
       - name: Run mdbook --version
-        run: echo "::set-output name=mdbook_version::$(mdbook --version)"
+        shell: bash
+        run: echo "mdbook_version=$(mdbook --version)" >> "$GITHUB_OUTPUT"
         id: mdbook_version
 
       - name: '${{ steps.mdbook_version.outputs.mdbook_version }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,48 +10,54 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       matrix:
         os:
-          - 'ubuntu-latest'
-          - 'ubuntu-20.04'
+          - 'ubuntu-24.04'
+          # Keep the previous LTS runner in the matrix for compatibility coverage.
+          - 'ubuntu-22.04'
           - 'macos-latest'
           - 'windows-latest'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Read .nvmrc
-        run: echo "::set-output name=NVMRC::$(cat .nvmrc)"
+        shell: bash
+        run: echo "NVMRC=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
         id: nvm
 
       - name: Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
       - run: npm ci
 
       - name: Run prettier
-        if: ${{ startsWith(matrix.os, 'ubuntu-latest') }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: npm run format:check
 
       - name: Run eslint
-        if: ${{ startsWith(matrix.os, 'ubuntu-latest') }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: npm run lint
 
       - name: Run ncc
-        if: ${{ startsWith(matrix.os, 'ubuntu-latest') }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: npm run build
 
       - run: npm test
 
       - name: Upload test coverage as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-${{ matrix.os }}
           path: coverage
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -4,18 +4,23 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: write
+
 jobs:
   update:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 1
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Update major tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           export TAG_NAME="${GITHUB_REF##refs/tags/}"
           export TAG_MAJOR="${TAG_NAME%%.*}"
           git tag --force -a "${TAG_MAJOR}" -m "Release ${TAG_NAME}"


### PR DESCRIPTION
## Summary
- Add minimum GitHub Actions permissions and job timeouts, and update Ubuntu runners.
- Pin action references to full commit SHAs, and update CodeQL and upload-artifact to supported versions.
- Replace deprecated set-output usage, fix the actionlint shellcheck finding, and remove the release workflow GitHub context dump.

## Notes
- Reviewed against the review-github-actions-workflows checklist, including actionlint findings, pinning, permissions, and timeouts.
- The existing Ubuntu 20.04 matrix entry is no longer available, so it was updated to Ubuntu 24.04 plus Ubuntu 22.04 compatibility coverage.
- Related issue: none.

## Test plan
- [x] actionlint
- [x] git diff --check
